### PR TITLE
Add rustfmt.toml

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,9 +1,9 @@
 #[tokio::main]
 async fn main() {
     let client = httpclient::Client::new()
-        .with_middleware(httpclient::middleware::RecorderMiddleware::new())
-        ;
-    let res = client.get("https://www.jsonip.com/")
+        .with_middleware(httpclient::middleware::RecorderMiddleware::new());
+    let res = client
+        .get("https://www.jsonip.com/")
         .header("secret", "foo")
         // .send_awaiting_body()
         .await

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+edition = "2021"
+version = "Two"
+reorder_imports = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+where_single_line = true
+trailing_comma = "Vertical"
+overflow_delimited_expr = true
+format_code_in_doc_comments = true
+normalize_comments = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,14 @@
 use std::fmt::Formatter;
 use std::str::FromStr;
+
 use http::Method;
 use hyper::client::HttpConnector;
-use hyper::{Uri};
+use hyper::Uri;
 use hyper_rustls::HttpsConnector;
 use once_cell::sync::OnceCell;
-use crate::RequestBuilder;
-use crate::middleware::Middleware;
-use crate::{Error, Request, Response};
 
+use crate::middleware::Middleware;
+use crate::{Error, Request, RequestBuilder, Response};
 
 static HTTPS_CONNECTOR: OnceCell<HttpsConnector<HttpConnector>> = OnceCell::new();
 
@@ -22,11 +22,7 @@ fn https_connector() -> &'static HttpsConnector<HttpConnector> {
     })
 }
 
-static APP_USER_AGENT: &str = concat!(
-    env!("CARGO_PKG_NAME"),
-    "/",
-    env!("CARGO_PKG_VERSION"),
-);
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 pub struct Client {
     base_url: Option<String>,
@@ -40,7 +36,6 @@ impl std::fmt::Debug for Client {
         write!(f, "Client {{ base_url: {:?} }}", self.base_url)
     }
 }
-
 
 impl Client {
     pub fn new() -> Self {
@@ -70,44 +65,66 @@ impl Client {
                 return uri;
             }
         }
-        let uri = self.base_url.as_ref().map(|s| s.clone() + uri_or_path).unwrap_or_else(|| uri_or_path.to_string());
+        let uri = self
+            .base_url
+            .as_ref()
+            .map(|s| s.clone() + uri_or_path)
+            .unwrap_or_else(|| uri_or_path.to_string());
         Uri::from_str(&uri).unwrap()
     }
 
     pub fn get(&self, url_or_path: &str) -> RequestBuilder<Client> {
         let uri = self.build_uri(url_or_path);
-        RequestBuilder::new(self, Method::GET, uri)
-            .headers(self.default_headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        RequestBuilder::new(self, Method::GET, uri).headers(
+            self.default_headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
     }
 
     pub fn post(&self, uri_or_path: &str) -> RequestBuilder<Client> {
         let uri = self.build_uri(uri_or_path);
-        RequestBuilder::new(self, Method::POST, uri)
-            .headers(self.default_headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        RequestBuilder::new(self, Method::POST, uri).headers(
+            self.default_headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
     }
 
     pub fn delete(&self, uri_or_path: &str) -> RequestBuilder {
         let uri = self.build_uri(uri_or_path);
-        RequestBuilder::new(self, Method::DELETE, uri)
-            .headers(self.default_headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        RequestBuilder::new(self, Method::DELETE, uri).headers(
+            self.default_headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
     }
 
     pub fn put(&self, uri_or_path: &str) -> RequestBuilder {
         let uri = self.build_uri(uri_or_path);
-        RequestBuilder::new(self, Method::PUT, uri)
-            .headers(self.default_headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        RequestBuilder::new(self, Method::PUT, uri).headers(
+            self.default_headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
     }
 
     pub fn patch(&self, uri_or_path: &str) -> RequestBuilder {
         let uri = self.build_uri(uri_or_path);
-        RequestBuilder::new(self, Method::PATCH, uri)
-            .headers(self.default_headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        RequestBuilder::new(self, Method::PATCH, uri).headers(
+            self.default_headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
     }
 
     pub fn request(&self, method: Method, uri_or_path: &str) -> RequestBuilder {
         let uri = self.build_uri(uri_or_path);
-        RequestBuilder::new(self, method, uri)
-            .headers(self.default_headers.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        RequestBuilder::new(self, method, uri).headers(
+            self.default_headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
     }
 
     // pub(crate) async fn start_request(&self, builder: RequestBuilder<'_>) -> Result<Response, Error> {
@@ -119,13 +136,18 @@ impl Client {
         self
     }
 
-    pub fn default_headers<S: AsRef<str>, I: Iterator<Item=(S, S)>>(mut self, headers: I) -> Self {
-        self.default_headers.extend(headers.map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()) ));
+    pub fn default_headers<S: AsRef<str>, I: Iterator<Item = (S, S)>>(
+        mut self,
+        headers: I,
+    ) -> Self {
+        self.default_headers
+            .extend(headers.map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string())));
         self
     }
 
     pub fn default_header<S: AsRef<str>>(mut self, key: S, value: S) -> Self {
-        self.default_headers.push((key.as_ref().to_string(), value.as_ref().to_string()));
+        self.default_headers
+            .push((key.as_ref().to_string(), value.as_ref().to_string()));
         self
     }
 
@@ -143,13 +165,12 @@ impl Default for Client {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    
-    use crate::middleware::{RecorderMiddleware, RecorderMode};
+
     use super::*;
+    use crate::middleware::{RecorderMiddleware, RecorderMode};
 
     #[tokio::test]
     async fn test_make_request() {
@@ -157,16 +178,21 @@ mod tests {
             .base_url("https://www.jsonip.com")
             .no_default_headers()
             .default_headers(vec![("User-Agent", "test-client")].into_iter())
-            .with_middleware(RecorderMiddleware::new()
-                .mode(RecorderMode::ForceNoRequests)
-            );
+            .with_middleware(RecorderMiddleware::new().mode(RecorderMode::ForceNoRequests));
 
-        let res = serde_json::to_value(client.get("/")
-            .await
-            .unwrap()
-            .json::<HashMap<String, String>>()
-            .await
-            .unwrap()).unwrap();
-        assert_eq!(res, serde_json::json!({"ip":"70.107.97.117","geo-ip":"https://getjsonip.com/#plus","API Help":"https://getjsonip.com/#docs"}));
+        let res = serde_json::to_value(
+            client
+                .get("/")
+                .await
+                .unwrap()
+                .json::<HashMap<String, String>>()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            res,
+            serde_json::json!({"ip":"70.107.97.117","geo-ip":"https://getjsonip.com/#plus","API Help":"https://getjsonip.com/#docs"})
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,14 @@
 use std::error::Error as StdError;
 use std::fmt::{Debug, Display, Formatter};
 use std::string::FromUtf8Error;
+
 use http::StatusCode;
+
 use crate::{Body, InMemoryBody, InMemoryResponse};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub type InMemoryError = Error<InMemoryBody>;
 pub type InMemoryResult<T> = Result<T, InMemoryError>;
-
 
 #[derive(Debug)]
 pub enum ProtocolError {
@@ -96,7 +97,11 @@ impl<T: Debug> Debug for Error<T> {
             Error::JsonEncoding(e) => write!(f, "JsonEncodingError: {}", e),
             Error::IoError(e) => write!(f, "IoError: {}", e),
             Error::HttpError(r) => {
-                write!(f, "HttpError {{ status: {}, headers: {:?}, body: {:?} }}", r.parts.status, r.parts.headers, r.body)
+                write!(
+                    f,
+                    "HttpError {{ status: {}, headers: {:?}, body: {:?} }}",
+                    r.parts.status, r.parts.headers, r.body
+                )
             }
             Error::TooManyRedirects => write!(f, "TooManyRedirectsError"),
         }
@@ -112,7 +117,11 @@ impl<T: Debug> Display for Error<T> {
             Error::JsonEncoding(e) => write!(f, "JsonEncodingError: {}", e),
             Error::IoError(e) => write!(f, "IoError: {}", e),
             Error::HttpError(r) => {
-                write!(f, "HttpError {{ status: {}, headers: {:?}, body: {:?} }}", r.parts.status, r.parts.headers, r.body)
+                write!(
+                    f,
+                    "HttpError {{ status: {}, headers: {:?}, body: {:?} }}",
+                    r.parts.status, r.parts.headers, r.body
+                )
             }
             Error::TooManyRedirects => write!(f, "Too many redirects"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 pub use ::http::{Method, StatusCode, Uri};
-
 pub use body::{Body, InMemoryBody};
 pub use client::Client;
 pub use error::{Error, InMemoryError, InMemoryResult, Result};
@@ -7,11 +6,11 @@ pub use middleware::Middleware;
 pub use request::{InMemoryRequest, Request, RequestBuilder};
 pub use response::{InMemoryResponse, Response};
 
+mod body;
 mod client;
 mod error;
+pub mod middleware;
 pub mod recorder;
 mod request;
 mod response;
-pub mod middleware;
-mod body;
 mod sanitize;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,11 +1,12 @@
 use std::str::FromStr;
-use crate::{Error, Response};
 
 use async_trait::async_trait;
 use http::Uri;
+
 use crate::client::Client;
-use crate::request::{Request};
 use crate::recorder::RequestRecorder;
+use crate::request::Request;
+use crate::{Error, Response};
 
 #[derive(Copy, Clone)]
 pub struct Next<'a> {
@@ -78,7 +79,6 @@ impl RecorderMiddleware {
     }
 }
 
-
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum RecorderMode {
     /// Default. Will check for recordings, but will make the request if no recording is found.
@@ -88,7 +88,6 @@ pub enum RecorderMode {
     /// Always use recordings. Fail if no recording is found.
     ForceNoRequests,
 }
-
 
 impl RecorderMode {
     pub fn should_lookup(self) -> bool {
@@ -108,7 +107,6 @@ impl RecorderMode {
     }
 }
 
-
 #[async_trait]
 impl Middleware for RecorderMiddleware {
     async fn handle(&self, request: Request, next: Next<'_>) -> Result<Response, Error> {
@@ -124,7 +122,8 @@ impl Middleware for RecorderMiddleware {
         }
         let response = next.run(request.clone().into()).await?;
         let response = response.into_content().await?;
-        self.request_recorder.record_response(request, response.clone())?;
+        self.request_recorder
+            .record_response(request, response.clone())?;
         Ok(response.into())
     }
 }
@@ -203,7 +202,12 @@ impl Middleware for FollowRedirectsMiddleware {
             if allowed_redirects == 0 {
                 return Err(Error::TooManyRedirects);
             }
-            let redirect = res.headers().get(http::header::LOCATION).expect("Received a 3xx status code, but no location header was sent.").to_str().unwrap();
+            let redirect = res
+                .headers()
+                .get(http::header::LOCATION)
+                .expect("Received a 3xx status code, but no location header was sent.")
+                .to_str()
+                .unwrap();
             let url = fix_url(request.url(), redirect);
             let request = request.clone();
             let request = request.set_url(url);
@@ -213,7 +217,6 @@ impl Middleware for FollowRedirectsMiddleware {
         Ok(res)
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,15 +1,14 @@
 use std::str::FromStr;
 
+pub use builder::RequestBuilder;
 use http::{HeaderMap, Version};
 use hyper::{Method, Uri};
-
-pub use builder::RequestBuilder;
 pub use memory::InMemoryRequest;
 
 use crate::{Body, InMemoryBody, Result};
 
-mod memory;
 mod builder;
+mod memory;
 
 #[derive(Debug)]
 pub struct Request<T = Body> {
@@ -96,7 +95,11 @@ impl Request {
     }
 
     pub fn build_delete(url: &str) -> RequestBuilder<(), InMemoryBody> {
-        RequestBuilder::new(&(), Method::DELETE, Uri::from_str(url).expect("Invalid URL"))
+        RequestBuilder::new(
+            &(),
+            Method::DELETE,
+            Uri::from_str(url).expect("Invalid URL"),
+        )
     }
 }
 
@@ -121,9 +124,7 @@ impl From<Request> for hyper::Request<hyper::Body> {
         for (key, value) in value.headers.into_iter().filter_map(|(k, v)| Some((k?, v))) {
             builder = builder.header(key, value);
         }
-        builder
-            .body(value.body.into())
-            .unwrap()
+        builder.body(value.body.into()).unwrap()
     }
 }
 
@@ -133,9 +134,8 @@ mod tests {
 
     use serde_json::json;
 
-    use crate::Client;
-
     use super::*;
+    use crate::Client;
 
     #[test]
     fn test_push_query() {
@@ -148,10 +148,16 @@ mod tests {
 
     #[test]
     fn test_query() {
-        let r1 = Request::build_get("http://example.com/foo/bar")
-            .set_query(HashMap::from([("a", Some("b")), ("c", Some("d")), ("e", None)]));
+        let r1 = Request::build_get("http://example.com/foo/bar").set_query(HashMap::from([
+            ("a", Some("b")),
+            ("c", Some("d")),
+            ("e", None),
+        ]));
         assert_eq!(r1.uri.to_string(), "http://example.com/foo/bar?a=b&c=d&e=");
-        assert_eq!(r1.build().url().to_string(), "http://example.com/foo/bar?a=b&c=d&e=");
+        assert_eq!(
+            r1.build().url().to_string(),
+            "http://example.com/foo/bar?a=b&c=d&e="
+        );
     }
 
     #[test]
@@ -163,6 +169,10 @@ mod tests {
     #[test]
     fn test_request_builder() {
         let client = Client::new();
-        let _ = RequestBuilder::new(&client, Method::POST, "http://example.com/foo".parse().unwrap());
+        let _ = RequestBuilder::new(
+            &client,
+            Method::POST,
+            "http://example.com/foo".parse().unwrap(),
+        );
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,11 +1,10 @@
 use http::{HeaderMap, StatusCode, Version};
 use hyper::body::Bytes;
-use serde::{de::DeserializeOwned};
-
 pub use memory::*;
+use serde::de::DeserializeOwned;
 
-use crate::Result;
 use crate::body::Body;
+use crate::Result;
 
 mod memory;
 
@@ -14,7 +13,6 @@ pub struct Response<T = Body> {
     pub parts: ResponseParts,
     pub body: T,
 }
-
 
 impl Response {
     pub(crate) async fn into_content(self) -> Result<InMemoryResponse> {
@@ -52,10 +50,7 @@ impl Response {
 
 impl<T> Response<T> {
     pub fn from_parts(parts: ResponseParts, body: T) -> Self {
-        Self {
-            parts,
-            body,
-        }
+        Self { parts, body }
     }
 
     pub fn into_parts(self) -> (ResponseParts, T) {
@@ -74,7 +69,8 @@ impl<T> Response<T> {
         let value = self.parts.headers.get("set-cookie")?;
         let value = value.to_str().ok()?;
         let cookie = cookie::Cookie::split_parse_encoded(value);
-        let cookie = cookie.into_iter()
+        let cookie = cookie
+            .into_iter()
             .filter_map(|c| c.ok())
             .find(|c| c.name() == name)?;
         cookie.value_raw()
@@ -104,7 +100,6 @@ impl From<http::Response<hyper::Body>> for Response {
         }
     }
 }
-
 
 #[derive(Debug, Clone)]
 pub struct ResponseParts {

--- a/src/response/memory.rs
+++ b/src/response/memory.rs
@@ -1,22 +1,25 @@
 use http::{HeaderMap, StatusCode, Version};
 use hyper::body::Bytes;
-use serde::{Deserialize, Serialize, Serializer};
 use serde::de::{DeserializeOwned, Error};
 use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize, Serializer};
 
-use crate::{InMemoryBody, InMemoryResult, Response, Result};
 use crate::response::ResponseParts;
 use crate::sanitize::sanitize_headers;
+use crate::{InMemoryBody, InMemoryResult, Response, Result};
 
 pub type InMemoryResponse = Response<InMemoryBody>;
 
 impl InMemoryResponse {
     pub fn new(status: StatusCode, headers: HeaderMap, body: InMemoryBody) -> Self {
-        Self::from_parts(ResponseParts {
-            status,
-            headers,
-            version: Version::default(),
-        }, body)
+        Self::from_parts(
+            ResponseParts {
+                status,
+                headers,
+                version: Version::default(),
+            },
+            body,
+        )
     }
 
     pub fn text(self) -> Result<String> {
@@ -45,7 +48,9 @@ impl Serialize for InMemoryResponse {
         let mut map = serializer.serialize_map(Some(size))?;
         map.serialize_entry("status", &self.status().as_u16())?;
         // BTreeMap is sorted...
-        let ordered: BTreeMap<_, _> = self.headers().iter()
+        let ordered: BTreeMap<_, _> = self
+            .headers()
+            .iter()
             .map(|(k, v)| (k.as_str(), v.to_str().unwrap()))
             .collect();
         map.serialize_entry("headers", &ordered)?;
@@ -55,7 +60,9 @@ impl Serialize for InMemoryResponse {
 }
 
 impl<'de> Deserialize<'de> for InMemoryResponse {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> where {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> where {
         struct InMemoryResponseVisitor;
 
         impl<'de> serde::de::Visitor<'de> for InMemoryResponseVisitor {
@@ -65,9 +72,11 @@ impl<'de> Deserialize<'de> for InMemoryResponse {
                 formatter.write_str("A map with the following keys: status, headers, body")
             }
 
-            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error> where A: serde::de::MapAccess<'de> {
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            where A: serde::de::MapAccess<'de> {
                 use std::borrow::Cow;
                 use std::collections::BTreeMap;
+
                 use hyper::header::{HeaderName, HeaderValue};
 
                 let mut status = None;
@@ -80,15 +89,16 @@ impl<'de> Deserialize<'de> for InMemoryResponse {
                                 return Err(<A::Error as Error>::duplicate_field("status"));
                             }
                             let i = map.next_value::<u16>()?;
-                            status = Some(StatusCode::from_u16(i).map_err(|_e|
+                            status = Some(StatusCode::from_u16(i).map_err(|_e| {
                                 <A::Error as Error>::custom("Invalid value for field `status`.")
-                            )?);
+                            })?);
                         }
                         "headers" => {
                             if headers.is_some() {
                                 return Err(<A::Error as Error>::duplicate_field("headers"));
                             }
-                            headers = Some(map.next_value::<BTreeMap<Cow<'de, str>, Cow<'de, str>>>()?);
+                            headers =
+                                Some(map.next_value::<BTreeMap<Cow<'de, str>, Cow<'de, str>>>()?);
                         }
                         "data" | "body" => {
                             if body.is_some() {
@@ -102,8 +112,16 @@ impl<'de> Deserialize<'de> for InMemoryResponse {
                     }
                 }
                 let status = status.ok_or_else(|| Error::missing_field("status"))?;
-                let headers = HeaderMap::from_iter(headers.ok_or_else(|| Error::missing_field("headers"))?.iter()
-                    .map(|(k, v)| (HeaderName::from_bytes(k.as_bytes()).unwrap(), HeaderValue::from_str(v).unwrap()))
+                let headers = HeaderMap::from_iter(
+                    headers
+                        .ok_or_else(|| Error::missing_field("headers"))?
+                        .iter()
+                        .map(|(k, v)| {
+                            (
+                                HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                                HeaderValue::from_str(v).unwrap(),
+                            )
+                        }),
                 );
                 let body = body.ok_or_else(|| Error::missing_field("data"))?;
                 Ok(InMemoryResponse::new(status, headers, body))
@@ -113,7 +131,6 @@ impl<'de> Deserialize<'de> for InMemoryResponse {
         deserializer.deserialize_map(InMemoryResponseVisitor)
     }
 }
-
 
 impl Clone for InMemoryResponse {
     fn clone(&self) -> Self {
@@ -127,16 +144,24 @@ impl Clone for InMemoryResponse {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+
     use super::*;
 
     #[test]
     fn test_serialize() {
-        let mut response = InMemoryResponse::new(StatusCode::OK, HeaderMap::new(), InMemoryBody::new_json(json!({
-            "Password": "hunter2",
-            "email": "amazing",
-        })));
+        let mut response = InMemoryResponse::new(
+            StatusCode::OK,
+            HeaderMap::new(),
+            InMemoryBody::new_json(json!({
+                "Password": "hunter2",
+                "email": "amazing",
+            })),
+        );
         response.sanitize();
         let serialized = serde_json::to_string(&response).unwrap();
-        assert_eq!(serialized, r#"{"status":200,"headers":{},"body":{"Password":"**********","email":"amazing"}}"#);
+        assert_eq!(
+            serialized,
+            r#"{"status":200,"headers":{},"body":{"Password":"**********","email":"amazing"}}"#
+        );
     }
 }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -5,14 +5,17 @@ use serde_json::Value;
 
 static REGEX: OnceCell<Regex> = OnceCell::new();
 
-trait AsLowercase   {
+trait AsLowercase {
     fn as_lowercase(&self) -> std::borrow::Cow<str>;
 }
 
 impl AsLowercase for str {
     fn as_lowercase(&self) -> std::borrow::Cow<str> {
         use std::borrow::Cow;
-        if let Some(first_uppercase) = self.bytes().position(|b| b.is_ascii_alphabetic() && !b.is_ascii_lowercase()) {
+        if let Some(first_uppercase) = self
+            .bytes()
+            .position(|b| b.is_ascii_alphabetic() && !b.is_ascii_lowercase())
+        {
             let mut string = String::with_capacity(self.len());
             string.push_str(&self[..first_uppercase]);
             for b in self[first_uppercase..].chars() {
@@ -27,13 +30,9 @@ impl AsLowercase for str {
 
 fn regex() -> &'static Regex {
     REGEX.get_or_init(|| {
-        let s = [
-            "secret",
-            "key",
-            "pkey",
-            "session",
-            "password"
-        ].map(|s| format!(r#"(\b|[-_]){s}(\b|[-_])"#)).join("|");
+        let s = ["secret", "key", "pkey", "session", "password"]
+            .map(|s| format!(r#"(\b|[-_]){s}(\b|[-_])"#))
+            .join("|");
         Regex::new(&format!(r#"(?i)({s})"#)).unwrap()
     })
 }


### PR DESCRIPTION
To facilitate parallel development by multiple contributors, we can provide a unified rustfmt.toml file in the code repository to minimize the chance of conflicts during git merge. This rustfmt.toml file in this PR is from the Databend project, which I personally prefer.